### PR TITLE
deprecate addgroup

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: 3.9
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: 3.9
+        python-version: ["3.9", "3.10"]
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 8
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,9 +19,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install software
         run: |
-          python -m pip install --upgrade pip --use-feature=2020-resolver
-          python -m pip install coveralls --use-feature=2020-resolver
-          python -m pip install .[dev] --use-feature=2020-resolver
+          python -m pip install --upgrade pip
+          python -m pip install coveralls
+          python -m pip install .[dev]
           python -m pip install https://github.com/bboe/coveralls-python/archive/github_actions.zip
       - name: Configure
         run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,7 +30,7 @@ jobs:
           printf "[aws]\nconfigured = True\n" > ~/.aws/cloudknot
       - name: Lint with flake8
         run: |
-          flake8
+          flake8 --exclude /home/runner/work/cloudknot/cloudknot/cloudknot/_version.py, /home/runner/work/cloudknot/cloudknot/cloudknot/cli.py
           black --check .
           pydocstyle
       - name: Test

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -30,7 +30,7 @@ jobs:
           printf "[aws]\nconfigured = True\n" > ~/.aws/cloudknot
       - name: Lint with flake8
         run: |
-          flake8 --exclude /home/runner/work/cloudknot/cloudknot/cloudknot/_version.py, /home/runner/work/cloudknot/cloudknot/cloudknot/cli.py
+          flake8
           black --check .
           pydocstyle
       - name: Test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: 22.1.0
+    rev: 23.7.0
     hooks:
     - id: black
-      language_version: python3.9

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -669,6 +669,7 @@ def get_user():
     username = user_info.get("UserName")
     if username is None:
         username = user_info.get("Arn").split(":")[-1]
+    username = username.replace("_", "-")
 
     return username
 

--- a/cloudknot/aws/base_classes.py
+++ b/cloudknot/aws/base_classes.py
@@ -251,6 +251,7 @@ def get_s3_params():
 
         # Use set_s3_params to check for name availability
         # and write to config file
+        bucket = bucket.replace("_", "-")  # S3 does not allow underscores
         set_s3_params(bucket=bucket, policy=policy, sse=sse)
 
         if policy is None:
@@ -669,7 +670,6 @@ def get_user():
     username = user_info.get("UserName")
     if username is None:
         username = user_info.get("Arn").split(":")[-1]
-    username = username.replace("_", "-")
 
     return username
 

--- a/cloudknot/cloudknot.py
+++ b/cloudknot/cloudknot.py
@@ -5,10 +5,9 @@ import ipaddress
 import logging
 import os
 
-try:
-    from collections.abc import Iterable, namedtuple
-except ImportError:
-    from collections import Iterable, namedtuple
+from collections.abc import Iterable
+from collections import namedtuple
+
 from concurrent.futures import ThreadPoolExecutor
 
 from . import aws

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref1/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref1/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 # Add user to "staff" group.
 # Give user a home directory.
 RUN (id -u cloudknot-user >/dev/null 2>&1 || useradd cloudknot-user) \
-    && addgroup cloudknot-user staff \
+    && usermod -a -G staff "cloudknot-user" \
     && mkdir -p /home/cloudknot-user \
     && chown -R cloudknot-user:staff /home/cloudknot-user
 

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref1/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref1/Dockerfile
@@ -13,18 +13,17 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 # Create a default user. Available via runtime flag `--user cloudknot-user`.
 # Add user to "staff" group.
 # Give user a home directory.
-RUN (id -u cloudknot-user >/dev/null 2>&1 || useradd cloudknot-user) \
-    && usermod -a -G staff "cloudknot-user" \
-    && mkdir -p /home/cloudknot-user \
-    && chown -R cloudknot-user:staff /home/cloudknot-user
-
-ENV HOME /home/cloudknot-user
-
-# Set working directory
-WORKDIR /home/cloudknot-user
-
-# Set entrypoint
-ENTRYPOINT ["python", "/home/cloudknot-user/unit-testing-func.py"]
+RUN groupadd -f staff \
+    && useradd --create-home --groups staff "cloudknot-user"
 
 # Copy the python script
-COPY unit-testing-func.py /home/cloudknot-user/
+COPY --chown="cloudknot-user" "unit-testing-func.py" "/home/cloudknot-user/"
+
+# Set user
+USER "cloudknot-user"
+
+# Set working directory
+WORKDIR "/home/cloudknot-user"
+
+# Set entrypoint
+ENTRYPOINT ["/home/cloudknot-user/unit-testing-func.py"]

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref1/unit-testing-func.py
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref1/unit-testing-func.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import boto3
 import cloudpickle
 import os

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref2/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref2/Dockerfile
@@ -13,18 +13,17 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 # Create a default user. Available via runtime flag `--user unit-test-username`.
 # Add user to "staff" group.
 # Give user a home directory.
-RUN (id -u unit-test-username >/dev/null 2>&1 || useradd unit-test-username) \
-    && usermod -a -G staff "${unit-test-username}" \
-    && mkdir -p /home/unit-test-username \
-    && chown -R unit-test-username:staff /home/unit-test-username
-
-ENV HOME /home/unit-test-username
-
-# Set working directory
-WORKDIR /home/unit-test-username
-
-# Set entrypoint
-ENTRYPOINT ["python", "/home/unit-test-username/test-func-input.py"]
+RUN groupadd -f staff \
+    && useradd --create-home --groups staff "unit-test-username"
 
 # Copy the python script
-COPY test-func-input.py /home/unit-test-username/
+COPY --chown="unit-test-username" "test-func-input.py" "/home/unit-test-username/"
+
+# Set user
+USER "unit-test-username"
+
+# Set working directory
+WORKDIR "/home/unit-test-username"
+
+# Set entrypoint
+ENTRYPOINT ["/home/unit-test-username/test-func-input.py"]

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref2/Dockerfile
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref2/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 # Add user to "staff" group.
 # Give user a home directory.
 RUN (id -u unit-test-username >/dev/null 2>&1 || useradd unit-test-username) \
-    && addgroup unit-test-username staff \
+    && usermod -a -G staff "${unit-test-username}" \
     && mkdir -p /home/unit-test-username \
     && chown -R unit-test-username:staff /home/unit-test-username
 

--- a/cloudknot/data/docker_reqs_ref_data/py3/ref2/test-func-input.py
+++ b/cloudknot/data/docker_reqs_ref_data/py3/ref2/test-func-input.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import boto3
 import cloudpickle
 import os

--- a/cloudknot/templates/Dockerfile.template
+++ b/cloudknot/templates/Dockerfile.template
@@ -23,8 +23,8 @@ ENV HOME /home/${username}
 # Set working directory
 WORKDIR /home/${username}
 
-# Set command to run
-CMD ["python", "/home/${username}/${script_base_name}"]
+# Set entrypoint
+ENTRYPOINT ["/usr/bin/python", "/home/${username}/${script_base_name}"]
 
 # Copy the python script
 COPY ${script_base_name} /home/${username}/

--- a/cloudknot/templates/Dockerfile.template
+++ b/cloudknot/templates/Dockerfile.template
@@ -13,18 +13,17 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt${github_installs_string}
 # Create a default user. Available via runtime flag `--user ${username}`.
 # Add user to "staff" group.
 # Give user a home directory.
-RUN (id -u ${username} >/dev/null 2>&1 || useradd ${username}) \
-    && usermod -a -G staff "${username}" \
-    && mkdir -p /home/${username} \
-    && chown -R ${username}:staff /home/${username}
-
-ENV HOME /home/${username}
-
-# Set working directory
-WORKDIR /home/${username}
-
-# Set entrypoint
-ENTRYPOINT ["python", "/home/${username}/${script_base_name}"]
+RUN groupadd -f staff \
+    && useradd --create-home --groups staff "${username}"
 
 # Copy the python script
-COPY ${script_base_name} /home/${username}/
+COPY --chown="${username}" "${script_base_name}" "/home/${username}/"
+
+# Set user
+USER "${username}"
+
+# Set working directory
+WORKDIR "/home/${username}"
+
+# Set entrypoint
+ENTRYPOINT ["/home/${username}/${script_base_name}"]

--- a/cloudknot/templates/Dockerfile.template
+++ b/cloudknot/templates/Dockerfile.template
@@ -24,7 +24,7 @@ ENV HOME /home/${username}
 WORKDIR /home/${username}
 
 # Set entrypoint
-ENTRYPOINT ["/usr/bin/python", "/home/${username}/${script_base_name}"]
+ENTRYPOINT ["python", "/home/${username}/${script_base_name}"]
 
 # Copy the python script
 COPY ${script_base_name} /home/${username}/

--- a/cloudknot/templates/Dockerfile.template
+++ b/cloudknot/templates/Dockerfile.template
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt${github_installs_string}
 # Add user to "staff" group.
 # Give user a home directory.
 RUN (id -u ${username} >/dev/null 2>&1 || useradd ${username}) \
-    && addgroup ${username} staff \
+    && usermod -a -G staff "${username}" \
     && mkdir -p /home/${username} \
     && chown -R ${username}:staff /home/${username}
 

--- a/cloudknot/templates/Dockerfile.template
+++ b/cloudknot/templates/Dockerfile.template
@@ -23,8 +23,8 @@ ENV HOME /home/${username}
 # Set working directory
 WORKDIR /home/${username}
 
-# Set entrypoint
-ENTRYPOINT ["python", "/home/${username}/${script_base_name}"]
+# Set command to run
+CMD ["python", "/home/${username}/${script_base_name}"]
 
 # Copy the python script
 COPY ${script_base_name} /home/${username}/

--- a/cloudknot/templates/script.template
+++ b/cloudknot/templates/script.template
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 import boto3
 import cloudpickle
 import os

--- a/cloudknot/templates/script.template
+++ b/cloudknot/templates/script.template
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import boto3
 import cloudpickle
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ exclude = '''
     | build
     | dist
   )/
-  | foo.py           # also separately exclude a file named foo.py in
-                     # the root of the project
+  | _version.py
+  | cli.py
 )
 '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    black==20.8b1
+    black==23.7.0
     coverage==5.3
     flake8==3.8.3
     numpydoc==1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,9 @@ setup_requires =
   setuptools_scm
 python_requires = >=3.6
 install_requires =
-    boto3>=1.5.21
-    awscli>=1.28.0
-    botocore>=1.8.36
+    boto3>=1.34.31
+    awscli>=1.32.31
+    botocore>=1.34.31
     cloudpickle
     docker>=3.0.0
     pipreqs>=0.4.11
@@ -57,7 +57,7 @@ dev =
     coverage==5.3
     flake8==3.8.3
     numpydoc==1.1.0
-    moto[cloudformation]==4.1.13
+    moto[cloudformation]==4.1.5
     pre-commit==3.3.3
     pydocstyle==5.1.1
     pytest-cov==2.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,4 +76,4 @@ match-dir = cloudknot
 max-line-length = 88
 select = C,E,F,W,B,B950
 ignore = E501,N802,N806,W503,E203
-exclude = setup.py,build,dist,doc,examples,cloudknot/data
+exclude = setup.py,build,dist,doc,examples,cloudknot/data,cloudknot/_version,cloudknot/cli

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,8 +57,7 @@ dev =
     coverage==5.3
     flake8==3.8.3
     numpydoc==1.1.0
-    moto>=2.2.13.dev2
-    responses==0.12.0
+    moto==4.1.13
     pre-commit==3.3.3
     pydocstyle==5.1.1
     pytest-cov==2.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,4 +76,4 @@ match-dir = cloudknot
 max-line-length = 88
 select = C,E,F,W,B,B950
 ignore = E501,N802,N806,W503,E203
-exclude = setup.py,build,dist,doc,examples,cloudknot/data,cloudknot/_version,cloudknot/cli
+exclude = setup.py,build,dist,doc,examples,cloudknot/data,cloudknot/_version.py,cloudknot/cli.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ dev =
     pytest-cov==2.10.1
     pytest-xdist[psutil]==2.1.0
     pytest==7.4.0
-    sphinx==3.2.1
+    sphinx==7.1.1
 maint =
     rapidfuzz==0.12.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,4 +76,4 @@ match-dir = cloudknot
 max-line-length = 88
 select = C,E,F,W,B,B950
 ignore = E501,N802,N806,W503,E203
-exclude = setup.py,build,dist,doc,examples,cloudknot/data,cloudknot/_version.py,cloudknot/cli.py
+exclude = setup.py,build,dist,doc,examples,cloudknot/data

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ dev =
     numpydoc==1.1.0
     moto>=2.2.13.dev2
     responses==0.12.0
-    pre-commit==2.9.2
+    pre-commit==3.3.3
     pydocstyle==5.1.1
     pytest-cov==2.10.1
     pytest-xdist[psutil]==2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ dev =
     pytest-cov==2.10.1
     pytest-xdist[psutil]==2.1.0
     pytest==7.4.0
-    sphinx==4.5.0
+    sphinx==5.0.0
 maint =
     rapidfuzz==0.12.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,8 @@ setup_requires =
   setuptools_scm
 python_requires = >=3.6
 install_requires =
-    awscli
     boto3>=1.5.21
+    awscli>=1.28.0
     botocore>=1.8.36
     cloudpickle
     docker>=3.0.0
@@ -63,7 +63,7 @@ dev =
     pytest-cov==2.10.1
     pytest-xdist[psutil]==2.1.0
     pytest==7.4.0
-    sphinx==7.1.1
+    sphinx==4.5.0
 maint =
     rapidfuzz==0.12.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ dev =
     pydocstyle==5.1.1
     pytest-cov==2.10.1
     pytest-xdist[psutil]==2.1.0
-    pytest==6.0.1
+    pytest==7.4.0
     sphinx==3.2.1
 maint =
     rapidfuzz==0.12.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ dev =
     coverage==5.3
     flake8==3.8.3
     numpydoc==1.1.0
-    moto==4.1.13
+    moto[cloudformation]==4.1.13
     pre-commit==3.3.3
     pydocstyle==5.1.1
     pytest-cov==2.10.1


### PR DESCRIPTION
- RF: Use usermod instead of addgroup in the Dockerfile template.
- Apply change of adduser to usermod in the test Dockerfiles as well.
- Removes testing on older Python version (3.6 and 3.7)
- Build the docs only on 3.9
- Update call to pip installation.
- Build docs on both 3.9 and 3.10.
- Update black/pre-commit configuration/versions.
- More compatibility issues
- Update deprecated imports from the collections module.
- Upgrade black
- Don't flake8 these files.
- Maybe we do need the extensions for these two files.
- Exclude these directly on the CI.
- Turns out this is not a flake8 thing, but a black thing.
- Update pytest.
- Install moto with the optional cloudformation dependencies.
- Update to newer sphinx version.
- Replace underscore in username with dash, so that bucket names are S3-allowable
- Replace right before setting the bucket name
- Find a combination of awscli and sphinx versions that works
- Try adding a shebang to the template. Otherwise running into 'exec format error' on Batch
- use CMD instead of ENTRYPOINT
- Do the normal thing again
- Use ENTRYPOINT, but be explicit about the python to call
- User call directly to Python again as instructed in python docker docs.
- Upgrade sphinx version.
- Set "moto[cloudformation]==4.1.5" to address failures in test_docker_image and test_knot
- Updated Dockerfile template to address #305
- Update shebang to use `env` and ensure presence in data files
